### PR TITLE
Added env_logger to get log output

### DIFF
--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -15,6 +15,7 @@ tauri-build = { version = "1.4", features = [] }
 [dependencies]
 tauri = { version = "1.4", features = ["shell-open", "devtools"] }
 enigo = { version = "0.2.0-rc2" }
+env_logger = "0.10"
 
 
 [target.'cfg(any(windows, target_os = "macos"))'.dependencies]

--- a/desktop/src-tauri/src/main.rs
+++ b/desktop/src-tauri/src/main.rs
@@ -36,6 +36,7 @@ async fn press(key: String) -> Result<(), String> {
 }
 
 fn main() {
+    env_logger::init();
     tauri::Builder::default()
         .setup(|app| {
             let window = app.get_window("main").unwrap();


### PR DESCRIPTION
In order to debug the issue with enigo, it would be helpful to get the output of the log. With these changes, we should better be able to see what is going on. Please run with the application with the `RUST_LOG=trace` env var.
Example: `RUST_LOG=trace cargo run`

You don't need to merge the PR, if you do not want to add the new dependency. It is meant to make the debugging of the error easier. Feel free to close it afterwards