### PR TITLE
GitHub Actions: `Detecting the operating system`

### DIFF
--- a/.github/workflows/desktop.yaml
+++ b/.github/workflows/desktop.yaml
@@ -37,11 +37,11 @@ jobs:
           # Those targets are only used on macos runners so it's in an `if` to slightly speed up windows and linux builds.
           targets: ${{ matrix.platform == 'macos-latest' && 'aarch64-apple-darwin,x86_64-apple-darwin' || '' }}
 
-      - name: install dependencies (ubuntu only)
-        if: matrix.platform == 'ubuntu-22.04' # This must match the platform value defined above.
+      - name: install dependencies (Linux only)
+        if: runner.os == 'Linux'
         run: |
           sudo apt-get update
-          sudo apt-get install -y libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev libappindicator3-dev librsvg2-dev patchelf
+          sudo apt-get install -y libappindicator3-dev librsvg2-dev libwebkit2gtk-4.0-dev libwebkit2gtk-4.1-dev patchelf
         # webkitgtk 4.0 is for Tauri v1 - webkitgtk 4.1 is for Tauri v2.
         # You can remove the one that doesn't apply to your app to speed up the workflow a bit.
 


### PR DESCRIPTION
GitHub Actions docs: [Detecting the operating system](https://docs.github.com/en/actions/writing-workflows/choosing-what-your-workflow-does/store-information-in-variables#detecting-the-operating-system) -- This approach allow changing the version of the OS without having to modify the `if:` statements.

`if: runner.arch == 'X64'`  # or `'ARM64'` can also be used

`install Rust stable` is not required because the Rust toolchain is [pre-installed](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2404-Readme.md#rust-tools) in all GitHub runner-images.

Keep `apt-get` dependencies sorted alphabetically to make it easy to spot missing dependencies and nearly impossible to add duplicates.